### PR TITLE
Regex is too greedy.

### DIFF
--- a/lib/Responsive_Content_Images.php
+++ b/lib/Responsive_Content_Images.php
@@ -86,7 +86,7 @@ class Responsive_Content_Images {
 		 * - The part after "size-" to catch the name of the image size that’s used.
 		 */
 		if ( preg_match_all(
-			'/<figure class="([^"]*wp-block-image size-([^\s]+)\s?[^"]*)"[^>]*><img [^>]+>.*<\/figure>/',
+			'/<figure class="([^"]*wp-block-image size-(\w+).*?)".*?><img [^>]+>.*<\/figure>/',
 			$content,
 			$block_images
 		) ) {


### PR DESCRIPTION
It would include trailing `"><..."` after the class name.